### PR TITLE
controller/updated composer.json with correct vendor-dir

### DIFF
--- a/web/composer.json
+++ b/web/composer.json
@@ -11,6 +11,6 @@
         "mongodb/mongodb": "^1.15"
     },
     "config": {
-        "vendor-dir": "lib/vendor"
+        "vendor-dir": "../lib/vendor"
     }
 }


### PR DESCRIPTION
In order to install dependencies with 'composer install' from /web project folder (where composer.json & composer.lock files are), a modification of composer.json is required to specify the correct /vendor folder location.
